### PR TITLE
StringUtilTest.populatePattern_default_over_empty_value() implies nul…

### DIFF
--- a/src/main/java/io/hyperfoil/tools/yaup/StringUtil.java
+++ b/src/main/java/io/hyperfoil/tools/yaup/StringUtil.java
@@ -85,7 +85,7 @@ public class StringUtil {
                 if(map.containsKey(name)){
                    replacement = map.get(name).toString();
                 }
-                if(replacement == null && defaultValue!=null && !defaultValue.isEmpty()){
+                if((replacement == null || "".equals(replacement)) && defaultValue!=null && !defaultValue.isEmpty()){
                     replacement = defaultValue;
                 }
                 if(StringUtil.findAny(name,"()/*^+-") > -1 ){


### PR DESCRIPTION
…l and zero length are treated as empty parameters and default should be used.

Assuming this is the intention, the test for returning defaultValue should cover both null and zero length string