### PR TITLE
Handle StringUtil.populatePattern() when JS eval fails

### DIFF
--- a/src/main/java/io/hyperfoil/tools/yaup/PopulatePatternException.java
+++ b/src/main/java/io/hyperfoil/tools/yaup/PopulatePatternException.java
@@ -3,11 +3,19 @@ package io.hyperfoil.tools.yaup;
 public class PopulatePatternException extends Exception {
 
     private String result;
+    private Boolean jsFailure;
+
     public PopulatePatternException(String s,String result) {
+        this(s, result, false);
+    }
+    public PopulatePatternException(String s,String result, Boolean jsFailure) {
         super(s);
         this.result = result;
+        this.jsFailure = jsFailure;
     }
     public String getResult(){return result;}
+
+    public Boolean isJsFailure(){ return jsFailure; }
 
     void setResult(String result){
         this.result = result;

--- a/src/main/java/io/hyperfoil/tools/yaup/StringUtil.java
+++ b/src/main/java/io/hyperfoil/tools/yaup/StringUtil.java
@@ -336,6 +336,7 @@ public class StringUtil {
     private static String populatePattern(String pattern, Map<Object,Object> map, Collection<String> evals, String prefix, String separator, String suffix, String javascriptPrefix, Set<String> seen, boolean fullScan) throws PopulatePatternException {
         boolean replaceMissing = false;
         PopulatePatternException toThrow = null;
+        JsException jsEvalException = null;
         if(map == null){
             map = new HashMap<>();
         }
@@ -429,7 +430,7 @@ public class StringUtil {
                             replacement = evalResult.toString();
                         }
                     }catch(JsException ise){
-                        //TODO failed to run javascript, save exception in case it was meant to be javascript but there is an error
+                        jsEvalException = ise;
                     }
                 }
                 if((replacement == null || "".equals(replacement))){
@@ -449,6 +450,9 @@ public class StringUtil {
             }
         }while(replaced);
         if(toThrow!=null){
+            if(jsEvalException != null){
+                throw new PopulatePatternException("Failed to evaluate JS: " + jsEvalException.getMessage(), rtrn, true);
+            }
             toThrow.setResult(rtrn);
             throw toThrow;
         }

--- a/src/test/java/perf/yaup/StringUtilTest.java
+++ b/src/test/java/perf/yaup/StringUtilTest.java
@@ -632,6 +632,25 @@ public class StringUtilTest {
       }
       fail("expected an exception from missing value");
    }
+
+   @Test
+   public void populatePattern_javascript_incorrect_filter(){
+      Map<Object, Object> map = new HashMap<>();
+      Json servers = Json.fromString("[ {\"name\":\"server-01\", \"idrac\":\"server01-drac.example.com\" } ]");
+      map.put("servers",servers);
+      map.put("missingTarget", "server01");
+
+      try {
+         String response = StringUtil.populatePattern("${{= ${{servers}}.filter(server => server.name === '${{missingTarget}}' )[0].idrac }}",map);
+      } catch (PopulatePatternException pe) {
+         assertTrue(pe.isJsFailure());
+         return;
+      }
+      fail("expected an exception from missing value");
+   }
+
+
+
    @Test(timeout = 10_000)
    public void populatePattern_looped_references(){
       Map<Object, Object> map = new HashMap<>();


### PR DESCRIPTION
add field `jsFailure` to `PopulatePatternException` to allow tracking of JavaScript evaluation failures and passing reason back to calling code